### PR TITLE
【FEAT】URL Clear ボタンの実装

### DIFF
--- a/discord-bot-helper/SendMessageView.swift
+++ b/discord-bot-helper/SendMessageView.swift
@@ -24,11 +24,22 @@ struct SendMessageView: View {
                 .ignoresSafeArea(edges: [.top])
             VStack(spacing: .zero) {
                 VStack(spacing: 8.0) {
-                    withIconTextFieldView(
-                        icon: Image(systemName: "link.icloud.fill"),
-                        placeholder: "URLを入れてください",
-                        text: $inputURL
-                    )
+                    HStack {
+                        withIconTextFieldView(
+                            icon: Image(systemName: "link.icloud.fill"),
+                            placeholder: "URLを入れてください",
+                            text: $inputURL
+                        )
+                        
+                        if !inputURL.isEmpty {
+                            Button(action: {
+                                inputURL = ""
+                            }, label: {
+                                Image(systemName: "xmark.circle.fill")
+                                    .foregroundStyle(.gray)
+                            })
+                        }
+                    }
 
                     withIconTextFieldView(
                         icon: Image(systemName: "rectangle.and.pencil.and.ellipsis"),


### PR DESCRIPTION
<!-- What's in this pull request? -->
## 概要 (Abstract)
webhook URL を一括で消去するボタンを実装
(文字入力がある時のみ)

<!-- If this pull request resolves any GitHub issues -->
## 関連するISSUE
- resolved #62 

## 詳細 (Detail)


<!-- Thank you for your contribution! -->
