### PR TITLE
【FIX】 Privacy Manifestの修正

### DIFF
--- a/discord-bot-helper/PrivacyInfo.xcprivacy
+++ b/discord-bot-helper/PrivacyInfo.xcprivacy
@@ -3,26 +3,11 @@
 <plist version="1.0">
 <dict>
 	<key>NSPrivacyAccessedAPITypes</key>
-	<array>
-		<dict/>
-	</array>
+	<array/>
 	<key>NSPrivacyCollectedDataTypes</key>
 	<array/>
 	<key>NSPrivacyTrackingDomains</key>
-	<array>
-		<dict>
-			<key>NSPrivacyCollectedDataType</key>
-			<string></string>
-			<key>NSPrivacyCollectedDataTypeLinked</key>
-			<false/>
-			<key>NSPrivacyCollectedDataTypeTracking</key>
-			<false/>
-			<key>NSPrivacyCollectedDataTypePurposes</key>
-			<array>
-				<string></string>
-			</array>
-		</dict>
-	</array>
+	<array/>
 	<key>NSPrivacyTracking</key>
 	<false/>
 </dict>


### PR DESCRIPTION
<!-- What's in this pull request? -->
## 概要 (Abstract)
デプロイで「バイナリが無効」と怒られたので修正

<!-- If this pull request resolves any GitHub issues -->
## 関連するISSUE
- resolved #92 

## 詳細 (Detail)
Swift-Protobuf のEmpty Manifestと同様にしています
https://github.com/apple/swift-protobuf/pull/1565/files

<!-- Thank you for your contribution! -->
